### PR TITLE
fix for Lean 4.12.0

### DIFF
--- a/HelloTypeSystem/ML3.lean
+++ b/HelloTypeSystem/ML3.lean
@@ -810,7 +810,8 @@ def Expr.extract (e : Expr) (Γ : TypeEnv) (bounded : e.fv ⊆ Γ.dom) (Λ : Lis
                   (fun h'' : a ∈ {y} =>
                     have hx := Singleton.mem_iff_eq_elem.mp (Expr.fv.Var ▸ h')
                     have hy := Singleton.mem_iff_eq_elem.mp h''
-                    absurd (hy ▸ hx) h
+                    have := hx ▸ hy
+                    absurd this.symm h
                   )
             (Var x).extract Γ' bounded' Λ
   | .Add e₁ e₂ =>

--- a/HelloTypeSystem/Util.lean
+++ b/HelloTypeSystem/Util.lean
@@ -12,7 +12,7 @@ def Set (α : Type u) := α → Prop
 
 @[simp]
 instance : Membership α (Set α) where
-  mem x s := s x
+  mem x s := x s
 
 instance : HasSubset (Set α) where
   Subset a b := ∀ x ∈ a, x ∈ b


### PR DESCRIPTION
https://github.com/leanprover/lean4/releases/tag/v4.12.0
> The parameters to Membership.mem have been swapped, which affects all Membership instances. (https://github.com/leanprover/lean4/pull/5020)
